### PR TITLE
i3status-rust: init package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ This overlay is built and (somewhat) tested against `nixos-unstable`.
 | wf-config | [2018-10-22 00:05](https://github.com/WayfireWM/wf-config/commits/8f7046e6c67d4a277b0793b56ff6535f53997bc5) |
 | redshift-wayland | [2018-09-01 12:25](https://github.com/minus7/redshift/commits/a2177ed9942477868ccc514372f32a0fbcbe189e) |
 | wmfocus | [2018-11-01 11:17](https://github.com/svenstaro/wmfocus/commits/d6f5ff88b7fb5d2eedde3c5989ae49a656ac5adb) |
+| i3status-rust | [2018-11-02 08:41](https://github.com/greshake/i3status-rust/commits/2b3ccf48721b3944281ee44a7e7562083471062d) |
 <!--pkgs-->
 
-Auto-update script last run: <!--update-->2018-11-05 03:43<!--update-->.
+Auto-update script last run: <!--update-->2018-11-05 03:58<!--update-->.
 
 Please open an issue if something is out of date.
 

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ swaypkgs = {
 
   # i3-related
   wmfocus          = self.callPackage ./wmfocus {};
+  i3status-rust    = self.callPackage ./i3status-rust {};
 };
 in
   swaypkgs // { inherit swaypkgs; }

--- a/i3status-rust/0001-Cargo.lock-regenerate.patch
+++ b/i3status-rust/0001-Cargo.lock-regenerate.patch
@@ -1,0 +1,973 @@
+From 3576c269d33b8405c8c1cb62bd9d325dff9498a3 Mon Sep 17 00:00:00 2001
+From: Cole Mickens <cole.mickens@gmail.com>
+Date: Mon, 5 Nov 2018 04:25:49 -0800
+Subject: [PATCH] Cargo.lock: regenerate
+
+---
+ Cargo.lock | 457 ++++++++++++++++++++++++++++++++-----------------------------
+ 1 file changed, 242 insertions(+), 215 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9630139..1cea358 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1,9 +1,9 @@
+ [[package]]
+ name = "aho-corasick"
+-version = "0.6.4"
++version = "0.6.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -11,17 +11,17 @@ name = "ansi_term"
+ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "atty"
+-version = "0.2.10"
++version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -29,52 +29,61 @@ name = "backtrace"
+ version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "backtrace-sys"
+-version = "0.1.16"
++version = "0.1.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "base64"
+-version = "0.1.1"
++version = "0.9.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
+ 
+ [[package]]
+ name = "bitflags"
+-version = "1.0.3"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bitflags"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "byteorder"
+-version = "1.2.2"
++version = "1.2.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.15"
++version = "1.0.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "cfg-if"
+-version = "0.1.3"
++version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "chan"
+-version = "0.1.21"
++version = "0.1.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -82,11 +91,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "chrono"
+-version = "0.4.2"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -95,22 +104,22 @@ name = "chrono-tz"
+ version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "parse-zoneinfo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "clap"
+-version = "2.31.2"
++version = "2.32.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -133,18 +142,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "dbus"
+-version = "0.6.1"
++version = "0.6.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libdbus-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "dtoa"
+-version = "0.4.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-
+ [[package]]
+ name = "encoding"
+ version = "0.2.33"
+@@ -215,7 +219,7 @@ name = "fuchsia-zircon"
+ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -226,44 +230,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "futures"
+-version = "0.1.21"
++version = "0.1.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "i3ipc"
+-version = "0.8.2"
++version = "0.8.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "i3status-rs"
+ version = "0.9.0"
+ dependencies = [
+- "chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+- "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chan 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "chrono-tz 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "dbus 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "i3ipc 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libpulse-binding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libpulse-binding 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "maildir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
++ "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -271,15 +275,15 @@ name = "inotify"
+ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+- "inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
++ "inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "inotify-sys"
+-version = "0.1.2"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -287,7 +291,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "itoa"
+-version = "0.4.1"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -306,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "lazy_static"
+-version = "1.0.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -316,27 +320,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "libdbus-sys"
+-version = "0.1.3"
++version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "libpulse-binding"
+-version = "2.2.1"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libpulse-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libpulse-sys 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "libpulse-sys"
+-version = "1.3.0"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -344,41 +349,55 @@ name = "log"
+ version = "0.3.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "log"
+-version = "0.4.1"
++version = "0.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "maildir"
+-version = "0.1.1"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "mailparse 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mailparse 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "mailparse"
+-version = "0.5.1"
++version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quoted_printable 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quoted_printable 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "memchr"
+-version = "2.0.1"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "nix"
++version = "0.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -386,9 +405,9 @@ name = "nix"
+ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -398,22 +417,22 @@ name = "num"
+ version = "0.1.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "num-bigint"
+-version = "0.1.43"
++version = "0.1.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -422,25 +441,25 @@ name = "num-complex"
+ version = "0.1.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "num-integer"
+-version = "0.1.36"
++version = "0.1.39"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "num-iter"
+-version = "0.1.35"
++version = "0.1.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -448,15 +467,15 @@ name = "num-rational"
+ version = "0.1.42"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "num-traits"
+-version = "0.2.3"
++version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -469,12 +488,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "pkg-config"
+-version = "0.3.11"
++version = "0.3.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "0.3.8"
++version = "0.4.20"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -485,20 +504,20 @@ name = "progress"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "0.5.2"
++version = "0.6.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "quoted_printable"
+-version = "0.3.3"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -508,22 +527,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "rand"
+-version = "0.4.2"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "redox_syscall"
+-version = "0.1.37"
++version = "0.1.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -531,7 +550,7 @@ name = "redox_termios"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -539,23 +558,23 @@ name = "regex"
+ version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "regex"
+-version = "1.0.0"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -563,20 +582,20 @@ name = "regex-syntax"
+ version = "0.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "regex-syntax"
+-version = "0.6.0"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "rustc-demangle"
+-version = "0.1.8"
++version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -584,29 +603,39 @@ name = "rustc-serialize"
+ version = "0.3.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
++[[package]]
++name = "ryu"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "safemem"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
+ [[package]]
+ name = "serde"
+-version = "1.0.53"
++version = "1.0.80"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.53"
++version = "1.0.80"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.17"
++version = "1.0.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -616,22 +645,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "syn"
+-version = "0.13.7"
++version = "0.15.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "terminal_size"
+-version = "0.1.7"
++version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -640,25 +668,24 @@ version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "textwrap"
+-version = "0.9.0"
++version = "0.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "thread_local"
+-version = "0.3.5"
++version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -667,26 +694,26 @@ version = "0.1.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "toml"
+-version = "0.4.6"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "ucd-util"
+-version = "0.1.1"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "unicode-width"
+-version = "0.1.4"
++version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -694,31 +721,28 @@ name = "unicode-xid"
+ version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "unreachable"
+-version = "1.0.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "utf8-ranges"
+-version = "1.0.0"
++version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "uuid"
+-version = "0.6.3"
++version = "0.6.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "vec_map"
+-version = "0.8.0"
++version = "0.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "version_check"
++version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -733,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "winapi"
+-version = "0.3.4"
++version = "0.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -756,24 +780,24 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [metadata]
+-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
++"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+ "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+-"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
++"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+ "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
+-"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
+-"checksum base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a51012ca17f843e723dedc71fdd7feac9d8b53be85492aa9232b2da59ce6bb3b"
+-"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+-"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+-"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
+-"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+-"checksum chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "9af7c487bb99c929ba2715b1a3a7bf45f5062bf5b6eae5d32b292a96c5865172"
+-"checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
++"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
++"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
++"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
++"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
++"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
++"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
++"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
++"checksum chan 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "d14956a3dae065ffaa0d92ece848ab4ced88d32361e7fdfbfd653a5c454a1ed8"
++"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+ "checksum chrono-tz 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa1878c18b5b01b9978d5f130fe366d434022004d12fb87c182e8459b427c4a3"
+-"checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
++"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+ "checksum cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33f07976bb6821459632d7a18d97ccca005cb5c552f251f822c7c1781c1d7035"
+ "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+-"checksum dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2c58aab20dd6637871e6e03cb6122f00b496a91eb65b688639c940012d8710"
+-"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
++"checksum dbus 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d975a175aa2dced1a6cd410b89a1bf23918f301eab2b6f7c5e608291b757639"
+ "checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+ "checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+ "checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+@@ -784,68 +808,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
+ "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+ "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+-"checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+-"checksum i3ipc 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a4e0c68a50475f32bf9a728de1198a8acc573ccdb24212db1192c874e37f302"
++"checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
++"checksum i3ipc 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0062d9e0f146755e3449fc3fd2ee02c4bedcb360f28d74ce1a05f8370da982f6"
+ "checksum inotify 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ad0bfe014aafc0f4e177fbe66c5f2b59ba59f66f58b022aa1963bbe71ab4118"
+-"checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
+-"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
++"checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
++"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+ "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+ "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
++"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+ "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+-"checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
+-"checksum libpulse-binding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cf8d18cd66838e8a2d049ea3b3ae6942e88ad007c2d593def703a1e7470e52"
+-"checksum libpulse-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5e1843312173214a21c7f7dabd0e2de467033355ed57366f64aadb2a288f47b"
++"checksum libdbus-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "99c78106156a964aadc1c59f7798276967be6705243b60f3ab7e131e3841db88"
++"checksum libpulse-binding 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "903bdbc13ff187b6de9c226c2c1e42c74f89b3ca705c28349b23dced3127b779"
++"checksum libpulse-sys 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d41d265aba27f73ef0a0b112cfa9046b90c2c08bec6e1884cffcbb3615e580"
+ "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+-"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+-"checksum maildir 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83d9b449b6ff23db5eda044963296380c74941ac9480fc629840d7405e436c73"
+-"checksum mailparse 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "517ae98201a037bbd2dccdf88763e5818b26fc98a46725ae524424de2f67339f"
+-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
++"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
++"checksum maildir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0159d4933082a0c579a741ef6b13b9bd0e18e400c894806d85815f622f569fd7"
++"checksum mailparse 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "779d1888b51590874182e85d983d2239e403227aa17c077625f1770aeb410f50"
++"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+ "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
++"checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"
+ "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+-"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
++"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+ "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
++"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
++"checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
+ "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+-"checksum num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c22f20a157cb4af265c71e47db525852368feeb4a0013f0f8c68a7f4ef0d0fc1"
++"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+ "checksum parse-zoneinfo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ee19a3656dadae35a33467f9714f1228dd34766dbe49e10e656b5296867aea"
+-"checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
++"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
++"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+ "checksum progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b820305721858696053a7fd0215cfeeee16ecaaf96b7a209945428e02f1c44"
+-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+-"checksum quoted_printable 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ec1a063e17beecae242623379d30100975588fb3d2a4bf1df8550d872268a89f"
++"checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
++"checksum quoted_printable 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4126fa98c6d7b166e6a29a24ab96721d618759d803df6a8cb35d6140da475b5a"
+ "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
+-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
++"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
++"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+ "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+ "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+-"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
++"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
+ "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+-"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
++"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
++"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+ "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+-"checksum serde 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "de4dee3b122edad92d80c66cac8d967ec7f8bf16a3b452247d6eb1dbf83c8f22"
+-"checksum serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7149ef7af607b09e0e7df38b1fd74264f08a29a67f604d5cb09d3fbdb1e256bc"
+-"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
++"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
++"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
++"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
++"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
++"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+ "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+-"checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
+-"checksum terminal_size 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4f7fdb2a063032d361d9a72539380900bc3e0cd9ffc9ca8b677f8c855bae0f"
++"checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
++"checksum terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "023345d35850b69849741bd9a5432aa35290e3d8eb76af8717026f270d1cf133"
+ "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
++"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
++"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+ "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+-"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
+-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
++"checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
++"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
++"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+ "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+-"checksum uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8630752f979f1b6b87c49830a5e3784082545de63920d59fbaac252474319447"
+-"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
++"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
++"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
++"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
++"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+ "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+ "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
++"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+ "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+ "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+ "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+-- 
+2.16.2
+

--- a/i3status-rust/default.nix
+++ b/i3status-rust/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, dbus, libpulseaudio }:
+
+let
+  metadata = import ./metadata.nix;
+in
+rustPlatform.buildRustPackage rec {
+  name = "i3status-rust-${version}";
+  version = metadata.rev;
+
+  src = fetchFromGitHub {
+    owner = "greshake";
+    repo = "i3status-rust";
+    rev = metadata.rev;
+    sha256 = metadata.sha256;
+  };
+  cargoPatches = [ ./0001-Cargo.lock-regenerate.patch ];
+
+  cargoSha256 = "149070170ydjgdifv4fa1a1fh3mvpbgvwrlb3107dpdch2z7k9b9";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ dbus libpulseaudio ];
+
+  meta = with stdenv.lib; {
+    description = "Very resource-friendly and feature-rich replacement for i3status";
+    homepage = https://github.com/greshake/i3status-rust;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.backuitist ];
+    platforms = platforms.linux;
+  };
+}

--- a/i3status-rust/metadata.nix
+++ b/i3status-rust/metadata.nix
@@ -1,0 +1,5 @@
+{
+  rev = "2b3ccf48721b3944281ee44a7e7562083471062d";
+  sha256 = "1imwbdld3vwjy9ha0wvi4zhflzjc4yawbzx8dd4d3nbwyrzdxzf4";
+  revdate = "2018-11-02T15:41:14Z";
+}

--- a/update.sh
+++ b/update.sh
@@ -56,6 +56,7 @@ update "redshift-wayland" "minus7"     "redshift"         "wayland"
 
 # i3-related
 update "wmfocus"          "svenstaro"  "wmfocus"          "master"
+update "i3status-rust"    "greshake"   "i3status-rust"    "master"
 
 #update "bspwc"      "Bl4ckb0ne"  "bspwc"            "master"
 #update "mahogany"   "sdilts"     "mahogany"         "master"


### PR DESCRIPTION
Currently failing:

```
building '/nix/store/8dbx2sm888nn0sw5cmqjfdxylmy2513x-i3status-rust-2b3ccf48721b3944281ee44a7e7562083471062d-vendor.drv'...
unpacking sources
unpacking source archive /nix/store/n78zcmpjvcgggs8vcgj0r4giz0hsj9qy-source
source root is source
patching sources
installing
error: failed to sync

Caused by:
  failed to load pkg lockfile

Caused by:
  failed to parse lock file at: /build/source/Cargo.lock

To learn more, run the command again with --verbose.
Traceback (most recent call last):
  File "/nix/store/d9malik4cg6za7d45gb86yl3rrrscvmv-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 42, in <module>
    main()
  File "/nix/store/d9malik4cg6za7d45gb86yl3rrrscvmv-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 17, in main
    assert list(data.keys()) == ["source"]
AssertionError
builder for '/nix/store/8dbx2sm888nn0sw5cmqjfdxylmy2513x-i3status-rust-2b3ccf48721b3944281ee44a7e7562083471062d-vendor.drv' failed with exit code 1
cannot build derivation '/nix/store/rl9fngv0vf5cz45z11nkvc7g6ha3difv-i3status-rust-2b3ccf48721b3944281ee44a7e7562083471062d.drv': 1 dependencies couldn't be built
error: build of '/nix/store/rl9fngv0vf5cz45z11nkvc7g6ha3difv-i3status-rust-2b3ccf48721b3944281ee44a7e7562083471062d.drv' failed
```