### PR TITLE
fixup sway-on-ubuntu, drop 18.09 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 Automated, pre-built packages for Wayland (sway/wlroots) tools for NixOS.
 
-This overlay is built and (somewhat) tested against `nixos-unstable`.
-(See the usage section for other options if your system is not on `nixos-unstable`.)
+Packages from this overlay are regularly updated and built against `nixos-unstable` and `nixpkgs-unstable`.
 
 (Sister repositories: [nixpkgs-kubernetes](https://github.com/colemickens/nixpkgs-kubernetes), [nixpkgs-colemickens](https://github.com/colemickens/nixpkgs-colemickens))
 
@@ -38,14 +37,13 @@ This overlay is built and (somewhat) tested against `nixos-unstable`.
 | pkgs/i3status-rust | [2018-11-12 05:55](https://github.com/greshake/i3status-rust/commits/b198b11e4b02b1a3b20fbfca103c35040435ad08) |
 <!--pkgs-->
 
-</details><br/>
+</details>
 
 ## Usage
 
-There are two ways to use this overlay on NixOS, depending on which
-nixpkgs channel you follow.
+Continue reading for usage instructions on NixOS (only the `nixos-unstable` is supported!).
 
-You can also use this [with Nix on Ubuntu, there is a full walkthrough](docs/sway-on-ubuntu/README.md).
+You can also use this [with Nix on Ubuntu. Please see the full walkthrough](docs/sway-on-ubuntu/).
 
 ### Usage (nixos-unstable)
 
@@ -70,45 +68,13 @@ in
   }
 ```
 
-### Usage (nixos-18.09)
-
-Rather than maintaining an unknown number of backports from nixos-unstable to here
-for supporting `nixos-18.09` users, these instructions will pull in select packages
-from `nixos-unstable + this overlay` to your environment.
-
-```nix
-{ config, lib, pkgs, ... }:
-let
-  url = "https://github.com/colemickens/nixpkgs-wayland/archive/master.tar.gz";
-  waylandPkgs = import "${builtins.fetchTarball url}/build.nix";
-in
-  {
-    nixpkgs.overlays = [ (self: super: { sway-beta = waylandPkgs.sway-beta; }) ];
-    hardware.opengl.enable = true;
-    environment.systemPackages =
-      with pkgs; [ vim git ] ++
-      (with waylandPkgs; [
-        grim slurp mako wlstream redshift-wayland # essentials
-        waybar i3status-rust # optional bars
-      ]);
-  }
-```
-
-Note: The `sway-beta` module is not available to you. As a result, you need to manually
-start sway with `dbus-launch` and you may have issues with `swaylock` due
-to the missing security functionality.
-
-```
-dbus-launch --exit-with-session $(which sway-beta)
-```
-
-
 ## Updates
 
 * `./update.sh`:
   * updates `pkgs/<pkg>/metadata.nix` with the latest commit+hash for each package
   * updates `nixpkgs/<channel>/metadata.nix` per the upstream channel
   * calls `nix-build build.nix` to build all packages against `nixos-unstable`
+  * calls `nix-build build.nixpkgs.nix` to build all packages against `nixpkgs-unstable`
   * pushes to [nixpkgs-wayland on cachix](https://nixpkgs-wayland.cachix.org)
 
 ## Binary Cache

--- a/docs/sway-on-ubuntu/README.md
+++ b/docs/sway-on-ubuntu/README.md
@@ -1,13 +1,8 @@
-# "sway-on-ubuntu"
-
-"sway-on-ubuntu" is a bad name, but so is "sway-on-ubuntu-via-nixpkgs".
-
-**!!**: *Please do not file bugs against Sway when using these packages.*
+# Sway on non-NixOS Distributions
 
 ## Walkthrough - NixGL + Sway on Ubuntu
 
-This guide will walk you through running `sway` on Ubuntu via `nix` and `nixpkgs`.
-In theory, this should work with a number of Ubuntu versions, but was tested with 18.10 under KVM.
+This guide will walk you through running `sway` on Ubuntu 18.10 via `nix` and `nixpkgs`.
 
 At a high-level:
 1. Install `nix`
@@ -19,10 +14,19 @@ At a high-level:
 
 ### Quick Version
 
-If you'd like the quick version, you can run `./execute` (aka `/docs/sway-on-ubuntu/execute.sh`)
-and then skip to the last step ("Run Sway").
+If you'd like the quick version, you can use the quickshot `execute.sh` script in this directory:
+```
+cd /tmp
+wget https://raw.githubusercontent.com/colemickens/nixpkgs-wayland/master/docs/sway-on-ubuntu/execute.sh
+chmod +x execute.sh
+./execute.sh
+```
 
-### Full Version
+[![Quick Steps Video on YouTube](https://img.youtube.com/vi/Sri_24TJtFI/0.jpg)](https://www.youtube.com/watch?v=Sri_24TJtFI)
+
+You can then skip to the end.
+
+### Detailed Version
 
 #### Install Nix
 
@@ -70,7 +74,8 @@ assuming enough RAM, CPU, etc.
 
 ```bash
 mkdir -p $HOME/.config/nixpkgs/overlays
-git clone https://github.com/colemickens/nixpkgs-wayland.git $HOME/.config/nixpkgs/overlays/nixpkgs-wayland
+git clone https://github.com/colemickens/nixpkgs-wayland.git \
+  $HOME/.config/nixpkgs/overlays/nixpkgs-wayland
 ```
 
 #### Install NixGL and Sway
@@ -83,25 +88,25 @@ the use of a wrapper. I've added some summary details to the NixOS Wiki:
 
 (Change the attribute to be installed per your GL vendor.)
 ```bash
-nix-env -iE '(import (builtins.fetchurl { url = "https://raw.githubusercontent.com/guibou/nixGL/master/default.nix"; })).nixGLIntel
+curl -L --fail https://raw.githubusercontent.com/guibou/nixGL/master/default.nix > /tmp/nixgl.nix
+```
+**Install Sway and related tools**
+```bash
+nix-env -iA nixGLIntel -f /tmp/nixgl.nix
+nix-env -iA nixpkgs.sway-beta nixpkgs.dmenu nixpkgs.mako nixpkgs.slurp nixpkgs.grim
 ```
 
-**Install Sway and a config file**
+This will install `sway-beta` the default configured channel for the Nix install you
+performed at the beginning, which is named `nixpkgs`. In our case though, `sway-beta`
+is overriden to a newer version by use of this overlay.
 
+**Install a demo Sway config**
 Install the default sway config:
 ```bash
-nix-env -iA nixpkgs.sway-beta nixpkgs.dmenu
-```
-
-This will install `sway-beta` from `nixpkgs` (the channel that Nix is configured to follow out
-of the box). In this case, `sway-beta` is actually a newer version coming from this overlay.
-
-```bash
-mkdir -p $HOME/.config/sway/config
+mkdir -p $HOME/.config/sway
 wget 'https://raw.githubusercontent.com/swaywm/sway/master/config.in' \
   -O $HOME/.config/sway/config
 
-# accomodate nested sway, remove missing BG, set $term
 sed -i 's|Mod4|Mod1|g' ~/.config/sway/config
 sed -i '/Sway_Wallpaper_Blue_1920x1080.png/d' ~/.config/sway/config
 sed -i 's|urxvt|gnome-terminal|g' ~/.config/sway/config
@@ -112,8 +117,11 @@ sed -i 's|urxvt|gnome-terminal|g' ~/.config/sway/config
 Let's drop to a TTY and try sway. **Note, this will stop GDM and your current session!**
 
 ```bash
-# from GNOME
+# stop the graphical session
 sudo systemctl isolate multi-user.target
+
+# switch to another TTY
+# ctrl+alt+f3
 
 # on TTY
 nixGLIntel sway

--- a/docs/sway-on-ubuntu/execute.sh
+++ b/docs/sway-on-ubuntu/execute.sh
@@ -1,37 +1,41 @@
 #!/usr/bin/env bash
-
+set +x
 echo "---------------------------------------------"
 echo "install nix"
-sudo apt update -qqy; sudo apt install -qqy curl git
-sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
-curl https://nixos.org/nix/install | sh
-source .nix-profile/etc/profile.d/nix.sh
+sudo apt-get update -qqy &>/dev/null; sudo apt-get install -qqy curl git &>/dev/null
+[[ -f "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]] && source ${HOME}/.nix-profile/etc/profile.d/nix.sh
+if ! which nix-env ; then
+  sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
+  curl --silent --fail https://nixos.org/nix/install | sh
+fi
+. "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 
+set -euo pipefail
 echo "---------------------------------------------"
 echo "install cachix"
-nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/889c72032f8595fcd7542c6032c208f6b8033db6
+nix-env -iA cachix -f "https://github.com/NixOS/nixpkgs/tarball/889c72032f8595fcd7542c6032c208f6b8033db6"
 
 echo "---------------------------------------------"
 echo "use nixpkgs-wayland binary cache"
-cachix use nixpkgs-wayland
+cachix use "nixpkgs-wayland"
 
 echo "---------------------------------------------"
-echo "activate `nixpkgs-wayland` overlay"
-mkdir -p $HOME/.config/nixpkgs/overlays
+echo "activate \"nixpkgs-wayland\" overlay"
+mkdir -p "$HOME/.config/nixpkgs/overlays"
 if [[ ! -d "${HOME}/.config/nixpkgs/overlays/nixpkgs-wayland" ]]; then
-  git clone https://github.com/colemickens/nixpkgs-wayland.git \
-    $HOME/.config/nixpkgs/overlays/nixpkgs-wayland
+  git clone "https://github.com/colemickens/nixpkgs-wayland.git" \
+    "$HOME/.config/nixpkgs/overlays/nixpkgs-wayland"
 fi
 
 echo "---------------------------------------------"
-echo "install NixGL, sway, dmenu"
-nix-env -iE '(import (builtins.fetchurl { url = "https://raw.githubusercontent.com/guibou/nixGL/master/default.nix"; })).nixGLIntel'
-
-nix-env -iA nixpkgs.sway-beta nixpkgs.dmenu
+echo "install NixGL, sway, and sway tools"
+curl -L --fail https://raw.githubusercontent.com/guibou/nixGL/master/default.nix > /tmp/nixgl.nix
+nix-env -iA nixGLIntel -f /tmp/nixgl.nix
+nix-env -iA nixpkgs.sway-beta nixpkgs.dmenu nixpkgs.mako nixpkgs.slurp nixpkgs.grim
 
 echo "---------------------------------------------"
 echo "configuring sway"
-mkdir -p $HOME/.config/sway/config
+mkdir -p $HOME/.config/sway
 wget 'https://raw.githubusercontent.com/swaywm/sway/master/config.in' \
   -O $HOME/.config/sway/config
 
@@ -46,8 +50,8 @@ echo "now run:"
 echo " - sudo systemctl isolate multi-user.target (this will stop your GDM session)"
 echo " - nixGLIntel sway"
 echo "when in sway:"
-echo " - `alt+d` starts `dmenu`"
-echo " - `alt+enter` starts `gnome-terminal`"
+echo " - 'alt+d' starts 'dmenu'"
+echo " - 'alt+enter' starts 'gnome-terminal'"
 echo "---------------------------------------------"
 echo
 


### PR DESCRIPTION
This will:
* fixup the documentation for "Sway on Ubuntu"
* remove support (aka documentation) for 18.09. we already stopped building and caching the packages a few days ago, dropping docs reduces support burden

cc: @zimbatm 