### PR TITLE
swayidle: init at 2019-01-13T01:50:02Z

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ waylandPkgs = rec {
   wlroots          = pkgs.callPackage ./pkgs/wlroots {};
   wlroots-old      = pkgs.callPackage ./pkgs-temp/wlroots {};
   sway-beta        = pkgs.callPackage ./pkgs/sway-beta {};
+  swayidle         = pkgs.callPackage ./pkgs/swayidle {};
   grim             = pkgs.callPackage ./pkgs/grim {};
   slurp            = pkgs.callPackage ./pkgs/slurp {};
   mako             = pkgs.callPackage ./pkgs/mako {};

--- a/pkgs/swayidle/default.nix
+++ b/pkgs/swayidle/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja
+, pkgconfig, scdoc
+, wayland, libevdev, libxkbcommon, pcre, json_c, dbus
+, pango, cairo, libinput, libcap, pam, gdk_pixbuf
+, wlroots, wayland-protocols
+, buildDocs ? true
+}:
+
+let
+  metadata = import ./metadata.nix;
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "swayidle";
+  version = metadata.rev;
+
+  src = fetchFromGitHub {
+    owner = "swaywm";
+    repo = "swayidle";
+    rev = version;
+    sha256 = metadata.sha256;
+  };
+
+  nativeBuildInputs = [
+    pkgconfig meson ninja
+  ] ++ stdenv.lib.optional buildDocs scdoc;
+
+  buildInputs = [
+    wayland wayland-protocols
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Sway's idle management daemon";
+    homepage    = https://swaywm.org;
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ primeos synthetica ]; # Trying to keep it up-to-date.
+  };
+}

--- a/pkgs/swayidle/metadata.nix
+++ b/pkgs/swayidle/metadata.nix
@@ -1,0 +1,5 @@
+{
+  rev = "1fe7145c186c285ee8036e364342195d53ac296b";
+  sha256 = "1d8952h9fjn57lfypx4qr4z7b4rkn4r4s9jq1gkw01xq0ch39i1j";
+  revdate = "2019-01-13T01:50:02Z";
+}

--- a/update.sh
+++ b/update.sh
@@ -41,6 +41,7 @@ update "pkgs/fmt"              "fmtlib"     "fmt"              "master"
 
 update "pkgs/wlroots"          "swaywm"     "wlroots"          "master"
 update "pkgs/sway-beta"        "swaywm"     "sway"             "master"
+update "pkgs/swayidle"         "swaywm"     "swayidle"         "master"
 update "pkgs/slurp"            "emersion"   "slurp"            "master"
 update "pkgs/grim"             "emersion"   "grim"             "master"
 update "pkgs/mako"             "emersion"   "mako"             "master"


### PR DESCRIPTION
swayidle has been split out of sway in https://github.com/swaywm/sway/commit/bc808680b173d5a3c4732265b33e2e8bd81e4d9b