### PR TITLE
update: sway-beta, swayidle, swaylock, waybar, wayfire, wl-clipboard, wlroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ Packages from this overlay are regularly updated and built against `nixos-unstab
 | Attribute Name | Last Upstream Commit Time |
 | -------------- | ------------------------- |
 | nixpkgs/nixos-unstable | [2019-01-20 09:32](https://github.com/nixos/nixpkgs-channels/commits/bc41317e24317b0f506287f2d5bab00140b9b50e) |
-| nixpkgs/nixpkgs-unstable | [2019-01-22 15:52](https://github.com/nixos/nixpkgs-channels/commits/1b3affcbaa8e31af0bfe1be280f91ac3e384d96f) |
-| pkgs/wlroots | [2019-01-22 13:58](https://github.com/swaywm/wlroots/commits/c41d01306de59235256d96902cced49a8eef15e9) |
-| pkgs/sway-beta | [2019-01-22 11:10](https://github.com/swaywm/sway/commits/9e6c6ce332a1d2b9e0387298e99bba824e0103a1) |
-| pkgs/swayidle | [2019-01-19 08:30](https://github.com/swaywm/swayidle/commits/72d15f8139705c1251aef7a7f7c64b8e527df206) |
-| pkgs/swaylock | [2019-01-22 06:11](https://github.com/swaywm/swaylock/commits/f0353900aed11f72f2f100cca1fcb60d34fc1c06) |
+| nixpkgs/nixpkgs-unstable | [2019-01-24 07:01](https://github.com/nixos/nixpkgs-channels/commits/11cf7d6e1ffd5fbc09a51b76d668ad0858a772ed) |
+| pkgs/wlroots | [2019-01-25 05:22](https://github.com/swaywm/wlroots/commits/209210d30780ec64995594b77fde3d718b655542) |
+| pkgs/sway-beta | [2019-01-24 06:24](https://github.com/swaywm/sway/commits/5f45a4bbc195400dd28e086c2e0e2f479b86e4eb) |
+| pkgs/swayidle | [2019-01-24 15:25](https://github.com/swaywm/swayidle/commits/f002a7a6e22704dbd2b195f43a604b22b55283ff) |
+| pkgs/swaylock | [2019-01-25 06:48](https://github.com/swaywm/swaylock/commits/368f53e4f15ecac51c01e6d1a45c43d31d4bca20) |
 | pkgs/slurp | [2019-01-09 15:24](https://github.com/emersion/slurp/commits/d9f3d741dc3de8c24198f41befc297e43054a523) |
 | pkgs/grim | [2019-01-11 14:45](https://github.com/emersion/grim/commits/b22b8a5ac3984c9b7d4ae5ba7ca112d3fd98b7a1) |
 | pkgs/mako | [2019-01-20 23:01](https://github.com/emersion/mako/commits/b30c786bdf8b90807e45ec0f52b292ee147ae1ff) |
 | pkgs/kanshi | [2019-01-09 09:05](https://github.com/emersion/kanshi/commits/c97715789db78a88970f6a4c86ecd9e59f156956) |
 | pkgs/wlstream | [2018-07-15 14:10](https://github.com/atomnuker/wlstream/commits/182076a94562b128c3a97ecc53cc68905ea86838) |
 | pkgs/oguri | [2019-01-19 14:57](https://github.com/vilhalmer/oguri/commits/88996939e8fb55c0a8d34596604660c87c585462) |
-| pkgs/waybar | [2019-01-14 00:05](https://github.com/Alexays/waybar/commits/aedf133b168ae780cb8688ef3e85abd143d79f3c) |
-| pkgs/wayfire | [2019-01-20 09:56](https://github.com/WayfireWM/wayfire/commits/f351b0766d27c3eb6b2b68f615bf7b6a1c193d2c) |
+| pkgs/waybar | [2019-01-25 07:42](https://github.com/Alexays/waybar/commits/a0fd99b1125ae34c5cd44baf29ccd0e8292ef0ef) |
+| pkgs/wayfire | [2019-01-24 12:52](https://github.com/WayfireWM/wayfire/commits/60ad07ededc2ff5005de2cb456254a4918c01768) |
 | pkgs/wf-config | [2018-12-17 00:04](https://github.com/WayfireWM/wf-config/commits/6d3426e216ac62ffa035035f9c1bea074e184018) |
 | pkgs/redshift-wayland | [2018-11-07 12:03](https://github.com/minus7/redshift/commits/420d0d534c9f03abc4d634a7d3d7629caf29b4b6) |
 | pkgs/bspwc | [2018-12-29 15:21](https://github.com/Bl4ckb0ne/bspwc/commits/e72ff641bd30d3db153d879cea1cffd149931546) |
 | pkgs/waybox | [2018-11-27 06:44](https://github.com/wizbright/waybox/commits/482d0a92f5530a5cbab8b0b913b653d4503015c4) |
-| pkgs/wl-clipboard | [2019-01-22 06:11](https://github.com/bugaevc/wl-clipboard/commits/580043e42534b550a4846d56f14a973e78da57c3) |
+| pkgs/wl-clipboard | [2019-01-25 08:52](https://github.com/bugaevc/wl-clipboard/commits/0915628c5bf32b0a78e61e769a2979615a34f2bd) |
 | pkgs/wmfocus | [2019-01-21 13:08](https://github.com/svenstaro/wmfocus/commits/69da8166d0cba19343d120e934c5088b8f8d0d43) |
 | pkgs/i3status-rust | [2018-12-24 09:01](https://github.com/greshake/i3status-rust/commits/31a595ee2b7ca84c3205560d96ec7bcf8ce02d0b) |
 <!--pkgs-->

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
 waylandPkgs = rec {
   # wlroots-related
   wlroots          = pkgs.callPackage ./pkgs/wlroots {};
-  #wlroots-old      = pkgs.callPackage ./pkgs-temp/wlroots {};
+  wlroots-old      = pkgs.callPackage ./pkgs-temp/wlroots {};
   sway-beta        = pkgs.callPackage ./pkgs/sway-beta {};
   swayidle         = pkgs.callPackage ./pkgs/swayidle {};
   swaylock         = pkgs.callPackage ./pkgs/swaylock {};
@@ -15,7 +15,7 @@ waylandPkgs = rec {
   oguri            = pkgs.callPackage ./pkgs/oguri {};
   waybar           = pkgs.callPackage ./pkgs/waybar {};
   wf-config        = pkgs.callPackage ./pkgs/wf-config {};
-  #wayfire          = pkgs.callPackage ./pkgs/wayfire { wlroots = wlroots-old; };
+  wayfire          = pkgs.callPackage ./pkgs/wayfire { wlroots = wlroots-old; };
   redshift-wayland = pkgs.callPackage ./pkgs/redshift-wayland {
     inherit (pkgs.python3Packages) python pygobject3 pyxdg wrapPython;
     geoclue = pkgs.geoclue2;

--- a/nixpkgs/nixpkgs-unstable/metadata.nix
+++ b/nixpkgs/nixpkgs-unstable/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "1b3affcbaa8e31af0bfe1be280f91ac3e384d96f";
-  sha256 = "0b7spivfa1fd07ch4plakp3j16pq9rjsg2ird3kz2sg86cwhhkcv";
-  revdate = "2019-01-22T23:52:12Z";
+  rev = "11cf7d6e1ffd5fbc09a51b76d668ad0858a772ed";
+  sha256 = "0zcg4mgfdk3ryiqj1j5iv5bljjvsgi6q6j9z1vkq383c4g4clc72";
+  revdate = "2019-01-24T15:01:49Z";
 }

--- a/pkgs/sway-beta/metadata.nix
+++ b/pkgs/sway-beta/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "9e6c6ce332a1d2b9e0387298e99bba824e0103a1";
-  sha256 = "1zm1g6lv8f2g55c0ybbnp7czgq0x1lvghwm3yz73i9rxvwv22bzd";
-  revdate = "2019-01-22T19:10:19Z";
+  rev = "5f45a4bbc195400dd28e086c2e0e2f479b86e4eb";
+  sha256 = "03fb41bm87ylxjampsivwahn68w9071bmakh83q7ca4hpp7j10y3";
+  revdate = "2019-01-24T14:24:02Z";
 }

--- a/pkgs/swayidle/metadata.nix
+++ b/pkgs/swayidle/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "72d15f8139705c1251aef7a7f7c64b8e527df206";
-  sha256 = "0bqmzs7vzni1gnsfp882zlv8cj939w2fpgy6fyb9zsl2fmmgi4ch";
-  revdate = "2019-01-19T16:30:58Z";
+  rev = "f002a7a6e22704dbd2b195f43a604b22b55283ff";
+  sha256 = "18vdgi2b134x5fcfczyc6x2nrwlnkn47p9pvza8yb4sf8ibmgf2k";
+  revdate = "2019-01-24T23:25:50Z";
 }

--- a/pkgs/swaylock/metadata.nix
+++ b/pkgs/swaylock/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "f0353900aed11f72f2f100cca1fcb60d34fc1c06";
-  sha256 = "1igvkp3ga5y79n7rh293s3i86fm12i1hyjpl9ml2nclqwz04kwcg";
-  revdate = "2019-01-22T14:11:36Z";
+  rev = "368f53e4f15ecac51c01e6d1a45c43d31d4bca20";
+  sha256 = "00x5yw8cp21dkjz6cv279jc6k970ixrbz39c7cm55liydbslqykh";
+  revdate = "2019-01-25T14:48:32Z";
 }

--- a/pkgs/waybar/metadata.nix
+++ b/pkgs/waybar/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "aedf133b168ae780cb8688ef3e85abd143d79f3c";
-  sha256 = "0k7izxwpjc96bj7wkvlp62g029i62xi1chvy5z5dr7dr3y9ckbjk";
-  revdate = "2019-01-14T08:05:52Z";
+  rev = "a0fd99b1125ae34c5cd44baf29ccd0e8292ef0ef";
+  sha256 = "05h2fn6z3x3jgkjyjr1q1gfnq9zk038624apc338ci4l02yibvfd";
+  revdate = "2019-01-25T15:42:41Z";
 }

--- a/pkgs/wayfire/metadata.nix
+++ b/pkgs/wayfire/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "f351b0766d27c3eb6b2b68f615bf7b6a1c193d2c";
-  sha256 = "1hrq4zv8lc3szwcg5vpkv1i08ia4cp8nhi4si1gfxsjrnlgj8ii1";
-  revdate = "2019-01-20T17:56:49Z";
+  rev = "60ad07ededc2ff5005de2cb456254a4918c01768";
+  sha256 = "1fah6ascmdjg1m4yl6vgpp8rpm2kzakma59m6wi4pc1c6dacghwr";
+  revdate = "2019-01-24T20:52:54Z";
 }

--- a/pkgs/wl-clipboard/metadata.nix
+++ b/pkgs/wl-clipboard/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "580043e42534b550a4846d56f14a973e78da57c3";
-  sha256 = "0dsh5a529lywr30z32rlrxlny0hg1pxjyp4a03c2l1nai7xx76vk";
-  revdate = "2019-01-22T14:11:44Z";
+  rev = "0915628c5bf32b0a78e61e769a2979615a34f2bd";
+  sha256 = "1fss2ff56mz07d90ayycf8q69ax639565km73apyjpjbd4j673md";
+  revdate = "2019-01-25T16:52:55Z";
 }

--- a/pkgs/wlroots/metadata.nix
+++ b/pkgs/wlroots/metadata.nix
@@ -1,5 +1,5 @@
 {
-  rev = "c41d01306de59235256d96902cced49a8eef15e9";
-  sha256 = "121i8slklacw5x37y95lmsmw22nzhmb8fm7199jsp3cyi5n9gqa8";
-  revdate = "2019-01-22T21:58:52Z";
+  rev = "209210d30780ec64995594b77fde3d718b655542";
+  sha256 = "1l8px2w5w8bpwi67ma2mwb4lxamaf51habaf1rc76g8bh3aavn67";
+  revdate = "2019-01-25T13:22:27Z";
 }


### PR DESCRIPTION
This should also resolve #79 by re-enabling `wayfire`.

(Fixes #79.)