### PR TITLE
swaylock: fix crypt/pam/suid problems

### DIFF
--- a/pkgs/sway-beta/default.nix
+++ b/pkgs/sway-beta/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dsway-version=${version}"
+    "-Ddefault-wallpaper=false"
     "-Dxwayland=enabled"
     "-Dtray=enabled"
     "-Dgdk-pixbuf=enabled"

--- a/pkgs/swayidle/default.nix
+++ b/pkgs/swayidle/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
     wayland wayland-protocols
   ];
 
+  mesonFlags = [
+    "-Dman-pages=enabled"
+    "-Dlogind=enabled"
+    "-Dlogind-provider=systemd"
+  ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/swaylock/default.nix
+++ b/pkgs/swaylock/default.nix
@@ -30,7 +30,12 @@ stdenv.mkDerivation rec {
     libxkbcommon cairo pango gdk_pixbuf pam
   ];
 
-  mesonFlags = "-Dswaylock-version=${version}";
+  mesonFlags = [
+    "-Dswaylock-version=${version}"
+    "-Dpam=enabled"
+    "-Dgdk-pixbuf=enabled"
+    "-Dman-pages=enabled"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
1. Fix `swaylock`. For some reason Meson seems to not be detecting pam, even though it finds it at compile time.

2. Set the feature flags for `sway*` packages so we're not relying on `meson` to do the right thing.

Fixes #82.

Signed-off-by: Cole Mickens <cole.mickens@gmail.com>