### PR TITLE
Fix build directory for waybar

### DIFF
--- a/pkgs/waybar/default.nix
+++ b/pkgs/waybar/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
   mesonFlags = [
     "-Dauto_features=enabled"
-    "-Dout=$out"
+    "-Dout=${out}"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Waybar is not building inside the $out directory, but inside the directory named '$out'. This PR change to a normal behavior.