### PR TITLE
wlr-randr: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These packages were mostly recently built against:
 | [wldash](https://wldash.org) | 2019-10-05 22:43:09 +0200 | Wayland launcher/dashboard |
 | [wlrobs](https://sr.ht/~scoopta/wlrobs) | 2019-03-16 15:06 -0700 | wlrobs is an obs-studio plugin that allows you to screen capture on wlroots based wayland compositors |
 | [wlroots](https://github.com/swaywm/wlroots) | 2019-11-03 00:17:23 +0000 | A modular Wayland compositor library |
+| [wlr-randr](https://github.com/ammen99/wf-recorder) | 2019-10-22 12:16:00 +0200 | Utility program for screen recording of wlroots-based compositors |
 | [wltrunk](https://git.sr.ht/~bl4ckb0ne/wltrunk) | 2019-10-03 16:14:27 -0400 | High-level Wayland compositor library based on wlroots |
 | [wtype](https://github.com/atx/wtype) | 2019-07-01 17:33:04 +0200 | xdotool type for wayland |
 | [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr) | 2019-07-24 19:38:20 +0300 | xdg-desktop-portal backend for wlroots |

--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,7 @@ waylandPkgs = rec {
   wl-clipboard     = pkgs.callPackage ./pkgs/wl-clipboard {};
   wldash           = pkgs.callPackage ./pkgs/wldash {};
   wlroots          = pkgs.callPackage ./pkgs/wlroots {};
+  wlr-randr        = pkgs.callPackage ./pkgs/wlr-randr {};
   wf-recorder      = pkgs.callPackage ./pkgs/wf-recorder {};
   wtype            = pkgs.callPackage ./pkgs/wtype {};
   xdg-desktop-portal-wlr = pkgs.callPackage ./pkgs/xdg-desktop-portal-wlr {};

--- a/pkgs/wlr-randr/default.nix
+++ b/pkgs/wlr-randr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig
+, wayland, wayland-protocols
+}:
+
+let
+  metadata = import ./metadata.nix;
+in
+stdenv.mkDerivation rec {
+  pname = "wlr-randr";
+  version = metadata.rev;
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = pname;
+    inherit (metadata) rev sha256;
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    wayland wayland-protocols
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An xrandr clone for wlroots compositors";
+    homepage = "https://github.com/emersion/wlr-randr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/wlr-randr/metadata.nix
+++ b/pkgs/wlr-randr/metadata.nix
@@ -1,0 +1,7 @@
+{
+  repo_git = "https://github.com/emersion/wlr-randr";
+  branch = "master";
+  rev = "c4066aa3249963dc7877119cffce10f3fa8b6304";
+  sha256 = "1ahw4sv07xg5rh9vr7j28636iaxs06vnybm3li6y8dz2sky7hk88";
+  revdate = "2019-03-22 16:38:05 +0200";
+}


### PR DESCRIPTION
Builds and runs:

```bash
$ $(nix-build build.nix -A nixosUnstable.wlr-randr)/bin/wlr-randr
eDP-1 "Sharp Corporation 0x148B 0x00000000 (eDP-1)"
  Physical size: 290x170 mm
  Enabled: yes
  Modes:
    3840x2160 px, 59.997002 Hz (preferred, current)
    3840x2160 px, 47.997002 Hz
  Position: 3440,0
  Transform: normal
  Scale: 3.000000
DP-2 "Dell Inc. Dell AW3418DW #ASPD8psOnhPd (DP-2)"
  Physical size: 800x340 mm
  Enabled: yes
  Modes:
    3440x1440 px, 59.973000 Hz (preferred, current)
    3440x1440 px, 120.000000 Hz
    3440x1440 px, 100.000000 Hz
    3440x1440 px, 84.963997 Hz
    3440x1440 px, 49.987000 Hz
    1024x768 px, 60.004002 Hz
    800x600 px, 60.317001 Hz
    640x480 px, 60.000000 Hz
    640x480 px, 59.939999 Hz
  Position: 0,0
  Transform: normal
  Scale: 1.000000

```