### PR TITLE
wlogout: fix hardcoded configuration path in program

### DIFF
--- a/pkgs/wlogout/default.nix
+++ b/pkgs/wlogout/default.nix
@@ -24,6 +24,22 @@ stdenv.mkDerivation rec {
     libxkbcommon gtk3
   ];
 
+  patchPhase = ''
+    substituteInPlace style.css --replace \
+      "/usr/share/wlogout" \
+      "$out/share/${pname}"
+
+    # Fix path in `access(/etc/wlogout/$config_file$)`
+    substituteInPlace main.c --replace \
+      "/etc/wlogout" \
+      "$out/etc/${pname}"
+  '';
+
+  mesonFlags = [
+    "--datadir=${placeholder "out"}/share"
+    "--sysconfdir=${placeholder "out"}/etc"
+  ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
wlogout would exit upon loading because it would fail to find its
configuration files (`layout` and `style.css`) in either `$XDG_CONFIG_HOME`
(which does not exist until the user creates the `wlogout` directory under
`$XDG_CONFIG_HOME`) or in its hardcoded static path.