### PR TITLE
imv: resume upgrades

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,13 +14,14 @@
       genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = genAttrs supportedSystems;
-      pkgsFor = pkgs: system:
+      pkgsFor = includeOverlay: pkgs: system:
         import pkgs {
           inherit system;
           config.allowUnfree = true;
-          overlays = [ inputs.self.overlay ];
+          overlays = if includeOverlay then [ inputs.self.overlay ] else [];
         };
-      pkgs_ = genAttrs (builtins.attrNames inputs) (inp: genAttrs supportedSystems (sys: pkgsFor inputs."${inp}" sys));
+      pkgs_ = genAttrs (builtins.attrNames inputs) (inp: genAttrs supportedSystems (sys: pkgsFor true inputs."${inp}" sys));
+      pkgs__ = genAttrs (builtins.attrNames inputs) (inp: genAttrs supportedSystems (sys: pkgsFor false inputs."${inp}" sys));
     in
     rec {
       overlay = final: prev:
@@ -33,7 +34,9 @@
             glpaper          = prev.callPackage ./pkgs/glpaper {};
             grim             = prev.callPackage ./pkgs/grim {};
             kanshi           = prev.callPackage ./pkgs/kanshi {};
-            imv              = prev.callPackage ./pkgs/imv {};
+            imv              = prev.callPackage ./pkgs/imv {
+              imv = prev.imv;
+            };
             lavalauncher     = prev.callPackage ./pkgs/lavalauncher {};
             mako             = prev.callPackage ./pkgs/mako {};
             nwg-launchers    = prev.callPackage ./pkgs/nwg-launchers {};

--- a/pkgs/imv/default.nix
+++ b/pkgs/imv/default.nix
@@ -1,62 +1,15 @@
 { stdenv, fetchFromGitHub
-, freeimage, fontconfig, pkgconfig
-, asciidoc, docbook_xsl, libxslt, cmocka
-, librsvg, pango, libxkbcommon, wayland
-, libGLU, icu
+, imv
 }:
 
 let metadata = import ./metadata.nix; in
-stdenv.mkDerivation rec {
-  pname = "imv";
+imv.overrideAttrs(old: {
+  pname = "imv-${metadata.rev}";
   version = metadata.rev;
-
   src = fetchFromGitHub {
     owner  = "eXeC64";
     repo   = "imv";
     rev    = metadata.rev;
     sha256 = metadata.sha256;
   };
-
-  preBuild = ''
-    # Version is 4.0.1, but Makefile was not updated
-    sed -i 's/^VERSION/c\VERSION = ${metadata.rev}/' Makefile
-  '';
-
-  nativeBuildInputs = [
-    asciidoc
-    cmocka
-    docbook_xsl
-    libxslt
-  ];
-
-  buildInputs = [
-    freeimage
-    libGLU
-    librsvg
-    libxkbcommon
-    pango
-    pkgconfig
-    wayland
-    icu
-  ];
-
-  installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];
-
-  postFixup = ''
-    # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,
-    # so we have to fix those to the binaries we installed into the /nix/store
-
-    sed -i "s|\bimv-wayland\b|$out/bin/imv-wayland|" $out/bin/imv
-    sed -i "s|\bimv-x11\b|$out/bin/imv-x11|" $out/bin/imv
-  '';
-
-  doCheck = true;
-
-  meta = with stdenv.lib; {
-    description = "A command line image viewer for tiling window managers";
-    homepage    = https://github.com/eXeC64/imv;
-    license     = licenses.gpl2;
-    maintainers = with maintainers; [ rnhmjoj markus1189 ];
-    platforms   = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
-  };
-}
+})

--- a/pkgs/imv/metadata.nix
+++ b/pkgs/imv/metadata.nix
@@ -1,7 +1,6 @@
 {
   repo_git = "https://github.com/eXeC64/imv";
   branch = "master";
-  rev = "a222f6475b905bdd0f55752e1539ed17bcad0a77";
-  sha256 = "0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
-  skip = true;
+  rev = "1b85ba53b0a8b44bb4330d7c86cefcf5ff1e0ab1";
+  sha256 = "sha256-tMeP7+bMkbEav+gOQDTxfc9GCdJ7tkdMvp0jHruxeJ4=";
 }


### PR DESCRIPTION
Unskip `imv` and build it with `meson`.

Blocked by https://github.com/eXeC64/imv/issues/228.