### PR TITLE
XWayland Pleasant Scaling

### DIFF
--- a/nixpkgs/nixos-unstable/default.nix
+++ b/nixpkgs/nixos-unstable/default.nix
@@ -1,7 +1,8 @@
 let
   meta = import ./metadata.nix;
 in
-  builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/archive/${meta.rev}.tar.gz";
-    sha256 = meta.sha256;
-  }
+  /home/cole/code/nixpkgs
+#  builtins.fetchTarball {
+#    url = "https://github.com/nixos/nixpkgs/archive/${meta.rev}.tar.gz";
+#    sha256 = meta.sha256;
+#  }

--- a/pkgs/sway/default.nix
+++ b/pkgs/sway/default.nix
@@ -4,6 +4,7 @@
 , wayland, libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf
 , wlroots, wayland-protocols
+, fetchpatch
 }:
 
 let metadata = import ./metadata.nix; in
@@ -21,6 +22,10 @@ stdenv.mkDerivation rec {
   patches = [
     ./sway-config-no-nix-store-references.patch
     ./load-configuration-from-etc.patch
+    (fetchpatch {
+      url = "https://github.com/swaywm/sway/pull/5090.patch";
+      sha256 = "11zsjzsg2lnbq9nzr7q9bm1x98rcijbc9dbknd7zbpwbrg8hdw23";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/wlroots/default.nix
+++ b/pkgs/wlroots/default.nix
@@ -19,6 +19,13 @@ in stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/swaywm/wlroots/pull/2064.patch";
+      sha256 = "0jvfxyx1nbvzljhdxbjcn4739lda61mfzpznvk9i5hw1pclbck4w";
+    })
+  ];
+
   # $out for the library, $bin for rootston, and $examples for the example
   # programs (in examples) AND rootston
   outputs = [ "out" "examples" ];


### PR DESCRIPTION
Hooray for a huge visual upgrade for XWayland apps on hidpi outputs under Sway!

<img src="https://i.imgur.com/jd34keZ.png" width=700 />

Step 1: Use this patch on the overlay.
Step 2: Use this branch of nixpkgs: https://github.com/colemickens/nixpkgs/tree/xwlscale

Then add `xwayland scale 2` to your config. For some reason `xwayland enable` doesn't work, but `xwayland force` does. At least, at the time of writing.

I'm not sure I'm good enough at Nix to add patched xserver/xwayland build as a separate package, and also make it easy for Sway to use it.

Unfortunately, this does trigger a small rebuild, as `gtksourceview4` uses `xvfb_run` to run its tests in a nested/virtual X server. (On my system, this resulted in Fractal, and virt-manager most notably being rebuilt.) But realistically it was less than 30 minutes on my laptop.

This is just for testing. Credit goes to the folks doing the work:
* https://gitlab.freedesktop.org/xorg/xserver/merge_requests/111 
* https://gitlab.freedesktop.org/xorg/xserver/merge_requests/111#note_406028
* Specifically, my nixpkgs branch and this PR use:
   * https://gitlab.freedesktop.org/dirbaio/xserver/tree/xwlScaling
   * https://github.com/Dirbaio/wlroots/tree/xwayland_hidpi
   * https://github.com/Dirbaio/sway/tree/xwayland_hidpi
* 