### PR TITLE
sway: patch version

### DIFF
--- a/pkgs/sway/default.nix
+++ b/pkgs/sway/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper
+{ stdenv, lib, fetchFromGitHub, makeWrapper
 , meson, ninja
 , pkgconfig, scdoc
 , wayland, libxkbcommon, pcre, json_c, dbus, libevdev
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # replace the version
+    date="$(date -d '${metadata.revdate}' +'%b %d %Y')"
+    sed -i "s/\([ \t]\)version: '\(.*\)',/\1version: '\2-${lib.substring 0 8 metadata.rev} ($date, branch \\\'${metadata.branch}\\\')',/" meson.build
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
```
$(nix-build build.nix -A sway-unwrapped)/bin/sway --version
# ...
sway version 1.4-c0811fcf8736961725f7aa848e740f38f2bdf6ed (2020-03-04 03:09:43 +0100, branch 'master')
```

seems a bit wordy, not sure the version is necessary.

cc @cole-h