### PR TITLE
pipewire webrtc screencasting

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,11 @@ waylandPkgs = rec {
 
   # pipewire related
   xdg-desktop-portal = pkgs.callPackage ./pkgs-temp/xdg-desktop-portal {};
+  google-chrome-with-pipewire = pkgs.callPackage ./pkgs/google-chrome-with-pipewire {
+    inherit (pkgs) google-chrome;
+    pipewire = pkgs.pipewire_0_2;
+  };
+  google-chrome = google-chrome-with-pipewire;
 };
 in
   waylandPkgs // { inherit waylandPkgs; }

--- a/default.nix
+++ b/default.nix
@@ -65,6 +65,9 @@ waylandPkgs = rec {
   # bspwc/wltrunk stuff
   bspwc    = pkgs.callPackage ./pkgs/bspwc { wlroots = wlroots-tmp; };
   wltrunk  = pkgs.callPackage ./pkgs/wltrunk { wlroots = wlroots-tmp; };
+
+  # pipewire related
+  xdg-desktop-portal = pkgs.callPackage ./pkgs-temp/xdg-desktop-portal {};
 };
 in
   waylandPkgs // { inherit waylandPkgs; }

--- a/pkgs-temp/xdg-desktop-portal/default.nix
+++ b/pkgs-temp/xdg-desktop-portal/default.nix
@@ -1,0 +1,92 @@
+{ stdenv
+, fetchFromGitHub
+, nixosTests
+, substituteAll
+, autoreconfHook
+, pkgconfig
+, libxml2
+, glib
+, pipewire
+, fontconfig
+, flatpak
+, gsettings-desktop-schemas
+, acl
+, dbus
+, fuse
+, libportal
+, geoclue2
+, json-glib
+, wrapGAppsHook
+}:
+
+let
+  metadata = import ./metadata.nix;
+in
+stdenv.mkDerivation rec {
+  pname = "xdg-desktop-portal";
+  version = metadata.rev;
+
+  outputs = [ "out" "installedTests" ];
+
+  src = fetchFromGitHub {
+    owner = "flatpak";
+    repo = pname;
+    rev = version;
+    sha256 = metadata.sha256;
+  };
+
+  patches = [
+    # Hardcode paths used by x-d-p itself.
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit flatpak;
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    libxml2
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    pipewire
+    fontconfig
+    flatpak
+    acl
+    dbus
+    geoclue2
+    fuse
+    libportal
+    gsettings-desktop-schemas
+    json-glib
+  ];
+
+  # Seems to get stuck after "PASS: test-portals 39 /portal/inhibit/monitor"
+  # TODO: investigate!
+  doCheck = false;
+
+  configureFlags = [
+    "--enable-installed-tests"
+  ];
+
+  makeFlags = [
+    "installed_testdir=${placeholder "installedTests"}/libexec/installed-tests/xdg-desktop-portal"
+    "installed_test_metadir=${placeholder "installedTests"}/share/installed-tests/xdg-desktop-portal"
+  ];
+
+  passthru = {
+    tests = {
+      installedTests = nixosTests.installed-tests.xdg-desktop-portal;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Desktop integration portals for sandboxed apps";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs-temp/xdg-desktop-portal/fix-paths.patch
+++ b/pkgs-temp/xdg-desktop-portal/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/notification.c b/src/notification.c
+index 5412609..4243e98 100644
+--- a/src/notification.c
++++ b/src/notification.c
+@@ -366,7 +366,7 @@
+   int status;
+   g_autofree char *err = NULL;
+   g_autoptr(GError) error = NULL;
+-  const char *icon_validator = LIBEXECDIR "/flatpak-validate-icon";
++  const char *icon_validator = "@flatpak@/libexec/flatpak-validate-icon";
+   const char *args[6];
+
+   if (G_IS_THEMED_ICON (icon))

--- a/pkgs-temp/xdg-desktop-portal/metadata.nix
+++ b/pkgs-temp/xdg-desktop-portal/metadata.nix
@@ -1,0 +1,5 @@
+{
+  rev = "1.7.2";
+  sha256 = "0rkwpsmbn3d3spkzc2zsd50l2r8pp4la390zcpsawaav8w7ql7xm";
+  revdate = "2020-04-03 14:44:44 +0200";
+}

--- a/pkgs/google-chrome-with-pipewire/default.nix
+++ b/pkgs/google-chrome-with-pipewire/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, symlinkJoin, makeWrapper
+, google-chrome
+, channel ? "stable"
+, pipewire
+}:
+
+stdenv.mkDerivation {
+  name = "google-chrome-with-pipewire-${google-chrome.version}";
+  buildInputs = [ makeWrapper ];
+  buildCommand = ''
+    case ${channel} in
+      beta) appname=chrome-beta      dist=beta     ;;
+      dev)  appname=chrome-unstable  dist=unstable ;;
+      *)    appname=chrome           dist=stable   ;;
+    esac
+
+    makeWrapper \
+      "$(readlink -v --canonicalize-existing "${google-chrome}/bin/google-chrome-$dist")" \
+      $out/bin/google-chrome-$dist \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ pipewire ]}
+  '';
+}


### PR DESCRIPTION
in order to get webrtc working with pipewire there are several things to be done.

some are done in this PR, some others have to be done be the user:

done in this PR:
- address webrtc-downstream-bug (has to be removed when [this](https://github.com/emersion/xdg-desktop-portal-wlr/issues/23) is done)
- use more recent versions of `xdg-desktop-portal` and `pipewire` (so fix a segfault i was running into)
- provide `pipewire_0_2` to chrome (done here with a wrapper)

to do by the user:
- set `XDG_CURRENT_DESKTOP=sway` environment variable
- enable a specific chrome-flag (`chrome://flags/#enable-webrtc-pipewire-capturer`)

up for discussion:
- is it feasible to provide a wrapper for chrome to provide the library? this would have to be done for chromium and vivaldi as well
- or should we rely on the user to set `LD_LIBRARY_PATH` globaly ?
- the chrome-flag could be provided with the wrapper as well (with `--enable-features=WebRTCPipeWireCapturer`)
- same applies `XDG_CURRENT_DESKTOP`