### PR TITLE
fix rpath for wlroots examples

### DIFF
--- a/pkgs/wlroots/default.nix
+++ b/pkgs/wlroots/default.nix
@@ -45,9 +45,6 @@ in stdenv.mkDerivation rec {
     mkdir -p $examples/bin
     cd ./examples
     for binary in $(find . -executable -type f -printf '%P\n' | grep -vE '\.so'); do
-       patchelf \
-         --set-rpath "$examples/lib:${stdenv.lib.makeLibraryPath buildInputs}" \
-         "$binary"
       cp "$binary" "$examples/bin/wlroots-$binary"
     done
   '';


### PR DESCRIPTION
wlroots examples link to `libwlroots`, which isn't in the search path of either `buildInputs` or `$examples/lib`, so they were failing to start.

Just removing the `patchelf` command fixes it.