### PR TITLE
Flakes support (and package set conversion)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,13 @@
+# reload when these files change
+watch_file flake.nix
+watch_file flake.lock
+
+# we don't have nix set to nixFlakes globally, so...
+if [[ ! -a /tmp/nixFlakes ]]; then
+  nix build -f "https://github.com/nixos/nixpkgs/archive/master.tar.gz" nixFlakes --out-link /tmp/nixFlakes
+fi
+
+# load the flake devShell
+eval "$(/tmp/nixFlakes/bin/nix \
+  --experimental-features 'nix-command flakes' \
+    print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ci/commit-message
+.direnv
 *.qcow2
 result
 result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "master": {
+      "locked": {
+        "lastModified": 1594418068,
+        "narHash": "sha256-E6KBMWS6NJIHYon5JHJudgKY4nhbOWKdje3FgfuyCrE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "57a53677b457e11c91c7ade1edab40fb82fc934d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1594369886,
+        "narHash": "sha256-qgj/Q11LIMZ9odF4XP0xBcjUbjiMvl/9uBb6wIx43l4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8d05772134f17180fb2711d0660702dae2a67313",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "master": "master",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+
+{
+  # TODO: rename git repot to 'flake-wayland-apps'
+  description = "wayland-apps";
+
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
+    master = { url = "github:nixos/nixpkgs/master"; }; # (for nixFlakes)
+  };
+
+  outputs = inputs:
+    let
+      metadata = builtins.fromJSON (builtins.readFile ./latest.json);
+
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+      forAllSystems = genAttrs [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+
+      overlay = import ./default.nix;
+      
+      pkgsFor = pkgs: system: includeOverlay:
+        import pkgs {
+          inherit system;
+          config.allowUnfree = true;
+          overlays = if includeOverlay then [ overlay ] else [];
+        };
+    in
+    rec {
+      devShell = forAllSystems (system:
+        let
+          nixpkgs_ = (pkgsFor inputs.nixpkgs system false);
+          master_ = (pkgsFor inputs.master system false);
+        in
+          nixpkgs_.mkShell {
+            nativeBuildInputs = with nixpkgs_; [
+              master_.nixFlakes
+              bash
+              cacert
+              cachix
+              curl
+              git
+              jq
+              mercurial
+              nix
+              nix-build-uncached
+              nix-prefetch
+              openssh
+              ripgrep
+            ];
+          }
+      );
+
+      packages = forAllSystems (system:
+        (pkgsFor inputs.nixpkgs system true).
+          waylandPkgs
+      );
+
+      defaultPackage = forAllSystems (system:
+        let
+          nixpkgs_ = (pkgsFor inputs.nixpkgs system true);
+          attrValues = inputs.nixpkgs.lib.attrValues;
+        in
+          nixpkgs_.symlinkJoin {
+            name = "nixpkgs-wayland";
+            paths = attrValues nixpkgs_.waylandPkgs;
+          }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,4 @@
-let
-  pkgs = import (import ./nixpkgs/nixos-unstable/default.nix) {};
-in
-pkgs. stdenv.mkDerivation {
-  name = "nixpkgs-wayland-devenv";
-
-  nativeBuildInputs = with pkgs; [
-    bash
-    cacert
-    cachix
-    curl
-    git
-    jq
-    mercurial
-    nix
-    nix-build-uncached
-    nix-prefetch
-    openssh
-    ripgrep
-  ];
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
 }
+).shellNix

--- a/update-flakes.sh
+++ b/update-flakes.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+
+nix --experimental-features 'nix-command flakes' \
+  flake update
+
+nix --experimental-features 'nix-command flakes' \
+  flake update --update-input nixpkgs
+
+nix --experimental-features 'nix-command flakes' \
+  flake update --update-input master
+
+nix --experimental-features 'nix-command flakes' \
+  build .

--- a/update.sh
+++ b/update.sh
@@ -177,3 +177,7 @@ nix-build \
   --option "build-cores" "0" \
   --option "narinfo-cache-negative-ttl" "0" \
   --keep-going build.nix | cachix push "${cache}"
+
+echo "**************************"
+echo "************************** FLAKES"
+./update-flakes.sh


### PR DESCRIPTION
This effectively converts the repo into a package set and adds flake support.

This is blocked on updated usage instructions that show how to use it as an overlay (so users can continue using it the same way they do now). This may require another output in the flake.