### PR TITLE
Update gebaar-libinput to use latest changes from the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ These packages were mostly recently built (and cached) against:
 | [cage](https://www.hjdskes.nl/projects/cage/) | A Wayland kiosk |
 | [clipman](https://github.com/yory8/clipman) | A basic clipboard manager for Wayland, with support for persisting copy buffers after an application exits |
 | [drm_info](https://github.com/ascent12/drm_info) | Small utility to dump info about DRM devices. |
-| [gebaar-libinput](https://github.com/Coffee2CodeNL/gebaar-libinput) | Gebaar, A Super Simple WM Independent Touchpad Gesture Daemon for libinput |
+| [emacs](https://www.gnu.org/software/emacs/) | The extensible, customizable GNU text editor |
+| [gebaar-libinput](https://github.com/Osleg/gebaar-libinput-fork) | Gebaar, A Super Simple WM Independent Touchpad Gesture Daemon for libinput |
 | [glpaper](https://bitbucket.org/Scoopta/glpaper) | GLPaper is a wallpaper program for wlroots based wayland compositors such as sway that allows you to render glsl shaders as your wallpaper |
 | [grim](https://github.com/emersion/grim) | Grab images from a Wayland compositor |
 | [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell) | A library to create panels and other desktop components for Wayland using the Layer Shell protocol |

--- a/pkgs/gebaar-libinput/default.nix
+++ b/pkgs/gebaar-libinput/default.nix
@@ -12,8 +12,8 @@ gcc8Stdenv.mkDerivation rec {
   version = metadata.rev;
 
   src = fetchFromGitHub {
-    owner = "Coffee2CodeNL";
-    repo = "gebaar-libinput";
+    owner = "Osleg";
+    repo = "gebaar-libinput-fork";
     rev = version;
     sha256 = metadata.sha256;
     fetchSubmodules = true;
@@ -28,7 +28,7 @@ gcc8Stdenv.mkDerivation rec {
 
   meta = with gcc8Stdenv.lib; {
     description = "Gebaar, A Super Simple WM Independent Touchpad Gesture Daemon for libinput";
-    homepage    = "https://github.com/Coffee2CodeNL/gebaar-libinput";
+    homepage    = "https://github.com/Osleg/gebaar-libinput-fork";
     license     = licenses.gpl3;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ colemickens ];

--- a/pkgs/gebaar-libinput/metadata.nix
+++ b/pkgs/gebaar-libinput/metadata.nix
@@ -1,6 +1,6 @@
 {
-  repo_git = "https://github.com/Coffee2CodeNL/gebaar-libinput";
+  repo_git = "https://github.com/Osleg/gebaar-libinput-fork";
   branch = "master";
-  rev = "c18c8bd73e79aaf1211bd88bf9cff808273cf6d6";
-  sha256 = "0crz4cbyn9g23n0bq40znrs3jc2pzrhyn8h6lxkk1hf89hwq6jxh";
+  rev = "8c3f67db473896fd8d369d7f8492a8c8e83b44a1";
+  sha256 = "KrWJBS/j1wD/2qyhlyThhEgRGwgLYIgGEBQsAU1r5hU=";
 }


### PR DESCRIPTION
The fork of `gebaar-libinput` has some additional features `gebaar-libinput` lacks.
This PR updates the branch from master to that of the PR.

Fork - https://github.com/osleg/gebaar-libinput-fork
Original - https://github.com/Coffee2CodeNL/gebaar-libinput

###### Context

I was cleaning up my Sway configuration and wondered what gebaar-libinput did.