### PR TITLE
wdisplays: add patch for cyclopsian/wdisplays#20

### DIFF
--- a/pkgs/wdisplays/default.nix
+++ b/pkgs/wdisplays/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub
+{stdenv, fetchFromGitHub, fetchpatch
 , meson, ninja, pkgconfig
 , gtk3, epoxy
 , wayland, wayland-protocols
@@ -18,6 +18,16 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = metadata.sha256;
   };
+
+  patches = [
+    # Fixes `Gdk-Message: 10:26:38.752: Error reading events from display: Success`
+    # https://github.com/cyclopsian/wdisplays/pull/20
+    (fetchpatch {
+      name = "001_use_correct_versions_when_binding_globals.patch";
+      url = "https://github.com/cyclopsian/wdisplays/commit/5198a9c94b40ff157c284df413be5402f1b75118.patch";
+      sha256 = "1xwphyn0ksf8isy9dz3mfdhmsz4jv02870qz5615zs7aqqfcwn85";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig meson ninja ] ++ stdenv.lib.optional buildDocs scdoc;
   buildInputs = [ gtk3 epoxy wayland wayland-protocols ];


### PR DESCRIPTION
wdisplays hasn't been working with Sway since Sway 1.5

See https://github.com/cyclopsian/wdisplays/pull/20