### PR TITLE
waypipe: nixify hardwired /usr/bin/ssh

### DIFF
--- a/pkgs/waypipe/default.nix
+++ b/pkgs/waypipe/default.nix
@@ -3,7 +3,7 @@
 , wayland, wayland-protocols
 , libffi, mesa_noglu
 , lz4, zstd, ffmpeg_4, libva
-, scdoc
+, scdoc, openssh
 }:
 
 let
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = metadata.sha256;
   };
+
+  postPatch = ''
+    substituteInPlace src/waypipe.c \
+      --replace "/usr/bin/ssh" "${openssh}/bin/ssh"
+  '';
 
   nativeBuildInputs = [ pkgconfig meson ninja python3 scdoc ];
   buildInputs = [


### PR DESCRIPTION
Prior to this change, when using the `waypipe ssh ...` form to run
waypipe, waypipe would fail to run ssh due to the path being hardcoded
to /usr/bin/ssh.

This change adds openssh as a dep and uses it to patch the hardwired
/usr/bin/ssh in waypipe.c.

https://gitlab.freedesktop.org/mstoeckl/waypipe/-/blob/cb173d0d9962a2e40001ec936ce72647b5d6a5ee/src/waypipe.c#L775