### PR TITLE
Update xdg-desktop-portal-wlr & hack path for iniparser

### DIFF
--- a/pkgs/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/xdg-desktop-portal-wlr/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
 , meson, ninja, pkgconfig
 , systemd, wayland, wayland-protocols
-, pipewire, libdrm
+, pipewire, libdrm, iniparser
 }:
 
 let
@@ -19,8 +19,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja ];
-  buildInputs = [ systemd wayland wayland-protocols pipewire libdrm ];
+  buildInputs = [ systemd wayland wayland-protocols pipewire libdrm iniparser];
   mesonFlags = [ "-Dauto_features=auto" ];
+
+  # iniparser is missing a pkg-config...
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "cc.find_library('iniparser', dirs: [join_paths(get_option('prefix'),get_option('libdir'))])" "cc.find_library('iniparser', dirs: ['${iniparser}/lib'])"
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/xdg-desktop-portal-wlr/metadata.nix
+++ b/pkgs/xdg-desktop-portal-wlr/metadata.nix
@@ -1,7 +1,6 @@
 {
   repo_git = "https://github.com/emersion/xdg-desktop-portal-wlr";
   branch = "master";
-  rev = "e103e120e20e83acec5b66ce4cd33a0eb86df0b0";
-  sha256 = "sha256-3WnWHn/YVrgEKI05tM5jnzxzBU3HUIh+EbyHFYcHX+4=";
-  skip = true;
+  rev = "ab8ff54f4c3e564595afefbcbdd6c87e2c8188f5";
+  sha256 = "sha256-ngtxBO0IfRWiAhHhEilhDF8eX1IpBs+wkUdvaZfBbGU=";
 }


### PR DESCRIPTION
auto-update(manual): xdg-desktop-portal-wlr: e103e120e20e83acec5b66ce4cd33a0eb86df0b0 => ab8ff54f4c3e564595afefbcbdd6c87e2c8188f5

Prior to this change, this package was pinned due to newer commits
referencing library: iniparser which is not distributed with a
pkg-config causing the build to fail on nix systems.

This change hacks around the problem by doing a replacement in
meson.build to cc.findlibrary(..) on the iniparser location in the nix
store.

Fixes: #283